### PR TITLE
skip items we will have to buy whose mall price is too high

### DIFF
--- a/scripts/vcon.ash
+++ b/scripts/vcon.ash
@@ -224,7 +224,7 @@ consumable find_profitable_consumable( item_set [] consumables, int size, int mp
 
     foreach index, set in consumables {
 	foreach consumable in set {
-	    // skip candies, since we'd prefer to use them for Swwet Synthesis
+	    // skip candies, since we'd prefer to use them for Sweet Synthesis
 	    if ( consumable.candy ) {
 		continue;
 	    }
@@ -235,11 +235,17 @@ consumable find_profitable_consumable( item_set [] consumables, int size, int mp
 		continue;
 	    }
 
-	    int price = retrieve_price( needed, consumable, true ) / needed;
-	    if ( price > max_price || price <= 0 ) {
-		// Too expensive or bogus (Speakeasy drinks are tradeable but have no mall price)
-		continue;
+	    if ( consumable.available_amount() < needed ) {
+		// We'll have to go to the mall for this item.
+		int mall = consumable.mall_price();
+		if ( mall > max_price || mall <= 0 ) {
+		    // Too expensive or bogus (Speakeasy drinks are tradeable but have no mall price)
+		    continue;
+		}
 	    }
+
+	    // calculate price to retrieve, accounting for valueOfInventory
+	    int price = retrieve_price( needed, consumable, true ) / needed;
 
 	    // Calculate how much Meat we expect to earn with this consumable's adventure yield
 	    int expected_income = my_expected_mpa * adventures;


### PR DESCRIPTION
```
> ash mall_price($item[Crimbo dinner])

Returned: 21000

> ash retrieve_price($item[Crimbo dinner])

Returned: 16800
```

The latter accounts for valueOfInventory of 1.8 - assuming you already own any of the item - but if you want to consume more than you own, you'll have to go to the mall - and if autoBuyPriceLimit < 21000, the purchase will fail.

If that situation holds while we are calculating "best consumables per size", skip this one, since we'll failure-loop while actually trying to consume.